### PR TITLE
Scripts use 'apt-get' never 'apt'

### DIFF
--- a/image/build-wheel.sh
+++ b/image/build-wheel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # FIXME
-apt install -y libglib2.0-dev
+apt-get -y install --no-install-recommends libglib2.0-dev
 
 cd /
 

--- a/image/provision.sh
+++ b/image/provision.sh
@@ -6,16 +6,16 @@ BAZEL_ROOT=https://github.com/bazelbuild/bazel/releases/download
 ln -s /usr/bin/python3 /usr/bin/python
 
 # Install prerequisites
-apt -y update
+apt-get -y update
 
-apt -y install \
+apt-get -y install --no-install-recommends \
     default-jdk python3-pip \
-    gfortran libgfortran-7-dev \
+    gcc g++ gfortran libgfortran-7-dev \
     libclang-9-dev clang-format-9 \
     git cmake ninja-build pkg-config \
     yasm patchelf wget zip
 
-apt -y install \
+apt-get -y install --no-install-recommends \
     libgl1-mesa-dev \
     opencl-headers ocl-icd-opencl-dev
 
@@ -25,6 +25,8 @@ pip3 install \
     auditwheel
 
 # Install bazel
+apt-get -y install --no-install-recommends \
+    unzip
 cd /tmp
 wget ${BAZEL_ROOT}/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
 bash /tmp/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh


### PR DESCRIPTION
https://manpages.debian.org/buster/apt/apt.8.en.html#SCRIPT_USAGE_AND_DIFFERENCES_FROM_OTHER_APT_TOOLS

This is only a partial fix.  We need to add a few more packaged dependencies before the build successfully completes again.

@mwoehlke-kitware Can you take over this patch and run with it until it's no longer a regression?

So far, it gets as far as:
```console
-- Looking for shmat - found
-- Found X11: /usr/lib/x86_64-linux-gnu/libX11.so
CMake Error at Rendering/OpenGL2/CMakeLists.txt:154 (message):
  X11_Xt_LIB could not be found.  Required for VTK X lib.


-- Configuring incomplete, errors occurred!
See also "/vtk/build/CMakeFiles/CMakeOutput.log".
See also "/vtk/build/CMakeFiles/CMakeError.log".
The command '/bin/sh -c /image/build-vtk.sh' returned a non-zero code: 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/pip-drake/1)
<!-- Reviewable:end -->
