### PR TITLE
Wheel updates

### DIFF
--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -23,7 +23,7 @@ build()
 extract()
 {
     docker run --rm $1 \
-        bash -c 'tar -cf - /wheel/dist/*.whl' | \
+        bash -c 'tar -cf - /wheel/wheelhouse/*.whl' | \
         tar --strip-components=2 -xf -
 }
 

--- a/image/build-dependencies.sh
+++ b/image/build-dependencies.sh
@@ -11,3 +11,5 @@ ninja
 
 ln -s /opt/drake-dependencies/lib/pkgconfig /usr/local/lib
 ln -s /opt/drake-dependencies/share/pkgconfig /usr/local/share
+
+ln -s /opt/drake-dependencies/bin/patchelf /usr/local/bin/patchelf

--- a/image/build-wheel.sh
+++ b/image/build-wheel.sh
@@ -32,5 +32,6 @@ chrpath '$ORIGIN/../lib' pydrake/*/*.so
 
 python setup.py bdist_wheel
 
-# FIXME
-# auditwheel repair dist/pydrake*.whl
+GLIBC_VERSION=$(ldd --version | sed -n '1{s/.* //;s/[.]/_/p}')
+
+auditwheel repair --plat manylinux_${GLIBC_VERSION}_x86_64 dist/drake*.whl

--- a/image/dependencies/projects.cmake
+++ b/image/dependencies/projects.cmake
@@ -1,3 +1,9 @@
+# patchelf
+set(patchelf_version 0.12)
+set(patchelf_url "https://github.com/NixOS/patchelf/archive/${patchelf_version}/patchelf-${patchelf_version}.tar.gz")
+set(patchelf_md5 "b9d1161e52e2f342598deabf7d85ed24")
+list(APPEND ALL_PROJECTS patchelf)
+
 # zlib
 set(zlib_version 1.2.11)
 set(zlib_url "https://github.com/madler/zlib/archive/v${zlib_version}.zip")

--- a/image/dependencies/projects/patchelf.cmake
+++ b/image/dependencies/projects/patchelf.cmake
@@ -1,0 +1,14 @@
+ExternalProject_Add(patchelf
+    URL ${patchelf_url}
+    URL_MD5 ${patchelf_md5}
+    ${COMMON_EP_ARGS}
+    BUILD_IN_SOURCE 1
+    PATCH_COMMAND ./bootstrap.sh
+    CONFIGURE_COMMAND ./configure
+        --prefix=${CMAKE_INSTALL_PREFIX}
+        --disable-shared
+        CFLAGS=-fPIC
+        CXXFLAGS=-fPIC
+    BUILD_COMMAND make
+    INSTALL_COMMAND make install
+    )

--- a/image/provision.sh
+++ b/image/provision.sh
@@ -9,12 +9,12 @@ ln -s /usr/bin/python3 /usr/bin/python
 apt-get -y update
 
 apt-get -y install --no-install-recommends \
-    default-jdk \
+    autoconf automake default-jdk \
     python3-dev libpython3-dev python3-pip \
     gcc g++ gfortran libgfortran-7-dev \
     libclang-9-dev clang-format-9 \
     git cmake ninja-build pkg-config \
-    yasm patchelf file wget unzip zip
+    yasm file wget unzip zip
 
 apt-get -y install --no-install-recommends \
     libglib2.0-dev \


### PR DESCRIPTION
Build our own `patchelf` so that we can use a newer version (0.12). Restore and repair invocation of auditwheel, which is working now with the updated version of patchelf. Update build-wheels.sh to pull the "audited" (and manylinux-tagged) wheel rather than the "unaudited" one.

Fixes robotlocomotion/drake#15655.

Note that I tried 0.13, but it SEGV'd during the Drake build. 0.12 does not seem to have this problem.