### PR TITLE
Add import name alias

### DIFF
--- a/image/setup.py
+++ b/image/setup.py
@@ -1,4 +1,5 @@
 import glob
+import os
 import setuptools
 from setuptools import setup, find_packages
 from setuptools.dist import Distribution
@@ -62,7 +63,32 @@ class BinaryDistribution(Distribution):
         return True
 
 
-setup(name='pydrake',
+def make_alias(name):
+    if name is None:
+        f = '__init__.py'
+        i = 'pydrake'
+    else:
+        f = f'{name}.py'
+        i = f'pydrake.{name}'
+
+    with open(os.path.join('drake', f), 'w') as m:
+        m.write(f'from {i} import *\n')
+
+
+os.makedirs('drake', exist_ok=True)
+
+make_alias(None)
+make_alias('all')
+make_alias('common')
+make_alias('examples')
+make_alias('forwarddiff')
+make_alias('manipulation')
+make_alias('multibody')
+make_alias('solvers')
+make_alias('systems')
+make_alias('visualization')
+
+setup(name='drake',
       version=DRAKE_VERSION,
       description='Model-based design and verification for robotics',
       long_description='''
@@ -104,7 +130,7 @@ heavy emphasis on optimization-based design/analysis.'''.strip(),
       python_requires='>=3.6',
       install_requires=python_required,
       ext_modules=[
-           setuptools.Extension(name='pydrake',
+           setuptools.Extension(name='drake',
                                 sources=[])],
       zip_safe=False
       )

--- a/image/setup.py
+++ b/image/setup.py
@@ -15,42 +15,16 @@ DRAKE_VERSION = '0.32.0'
 #      - lib/
 #      - manipulation/
 
-pydrake_lib = [
-    '../' + f
-    for f in glob.iglob("pydrake" + '**/**', recursive=True)
-    if '.so' in f
-]
-
-docs = [
-    '../' + f
-    for f in glob.iglob("pydrake/doc" + '**/**', recursive=True)
-]
-
-examples = [
-    '../' + f
-    for f in glob.iglob("pydrake/examples" + '**/**', recursive=True)
-]
-
-lib = [
-    '../' + f
-    for f in glob.iglob("pydrake/lib" + '**/**', recursive=True)
-]
-
-manipulation = [
-    '../' + f
-    for f in glob.iglob("pydrake/manipulation" + '**/**', recursive=True)
-]
-
 # Required python packages that will be pip installed along with pydrake
 # TODO Can we remove any of these?
 python_required = [
-  "matplotlib",
-  "meshcat",
-  "numpy",
-  "pydot",
-  "pygame",
-  "PyYAML",
-  "scipy"
+    'matplotlib',
+    'meshcat',
+    'numpy',
+    'pydot',
+    'pygame',
+    'PyYAML',
+    'scipy',
 ]
 
 
@@ -61,6 +35,10 @@ class BinaryDistribution(Distribution):
 
     def has_ext_modules(self):
         return True
+
+
+def find_data_files(pattern):
+    return [f'../{f}' for f in glob.iglob(pattern, recursive=True)]
 
 
 def make_alias(name):
@@ -124,8 +102,12 @@ heavy emphasis on optimization-based design/analysis.'''.strip(),
       # Add in any packaged data
       include_package_data=True,
       package_data={
-        'pydrake': ['../.drake-find_resource-sentinel'] + docs + examples +
-        lib + manipulation + pydrake_lib
+          '': ['.drake-find_resource-sentinel'] +
+          find_data_files('pydrake/**/*.so') +
+          find_data_files('pydrake/lib/**') +
+          find_data_files('pydrake/doc/**') +
+          find_data_files('pydrake/examples/**') +
+          find_data_files('pydrake/manipulation/**')
       },
       python_requires='>=3.6',
       install_requires=python_required,


### PR DESCRIPTION
Change the package name from 'pydrake' to 'drake' ('pydrake' is [already in use](https://pypi.org/project/pydrake/) for something completely different). Create an alias module so that `import drake` can be used. (Eventually we probably want to rename everything properly, but this gives us forward compatibility in the mean time.) Replace overly verbose logic to set up the lists of additional files to include in the wheel with a helper function invoked directly when setting `package_data`.

The existing packages have been created with this renaming applied locally; this will make it "official". (Note that I've also been locally modifying the version number.)