### PR TITLE
Enable Bazel caching across rebuilds via DOCKER_BUILDKIT 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,9 @@ ADD image/build-drake.sh /image/
 ADD image/pip-drake.patch /image/
 ADD ${REPO}/git/refs/heads/master /tmp/drake.sha
 
-RUN /image/build-drake.sh
+RUN \
+  --mount=target=/var/cache/bazel,type=cache \
+  /image/build-drake.sh
 
 ADD image/build-wheel.sh /image/
 ADD image/setup.py /wheel/

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -15,8 +15,10 @@ build()
     local id=$1
     shift 1
 
-    # Remove --force-rm if you need to inspect artifacts of a failed build
-    docker build --force-rm --tag $id "$@" "$(dirname "${BASH_SOURCE}")"
+    # Remove --force-rm if you need to inspect artifacts of a failed build.
+    # TODO(jwnimmer-tri) Figure out where buildkit stores its caches, so that
+    # we know how to clean them up once we no longer need them.
+    DOCKER_BUILDKIT=1 docker build --force-rm --tag $id "$@" "$(dirname "${BASH_SOURCE}")"
     trap "docker image rm $id" EXIT
 }
 

--- a/image/build-drake.sh
+++ b/image/build-drake.sh
@@ -9,6 +9,8 @@ cd /drake
 git apply < /image/pip-drake.patch
 
 bazel run \
+    --disk_cache=/var/cache/bazel/disk_cache \
+    --repository_cache=/var/cache/bazel/repository_cache \
     --repo_env=DRAKE_OS=manylinux \
     --define NO_CLP=ON \
     --define NO_IPOPT=ON \


### PR DESCRIPTION
Specifically:

- Cache the files downloaded via apt across Docker invocations, so that we don't pound the network when our apt dependencies change a little.
- Cache the bazel build results across Docker invocations, so that rebuilds are fast while testing small changes.

Eventually we may want a "gold build" flag that opts-out of caching for when we're actually doing real releases, or to make the caching opt-in, but during active development it seems like "fast by default" is better.

Also tidy up a few unrelated loose ends -- Bazel version, and capitalization.