### PR TITLE
Support multiple Python versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,22 @@
+ARG PLATFORM=ubuntu:18.04
+
 # -----------------------------------------------------------------------------
 # Create a base provisioned image
 # -----------------------------------------------------------------------------
 
-FROM ubuntu:18.04 AS base
+FROM ${PLATFORM} AS base
 
-ADD image/provision.sh /image/
+ARG PYTHON=3
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN /image/provision.sh
+
+ADD image/provision-base.sh /image/
+
+RUN /image/provision-base.sh
+
+ADD image/provision-python.sh /image/
+
+RUN /image/provision-python.sh ${PYTHON}
 
 # -----------------------------------------------------------------------------
 # Build Drake's dependencies

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -29,6 +29,13 @@ extract()
 
 ###############################################################################
 
-# Build wheel
-build $id
-extract $id
+# Build wheels
+build ${id}-py36 --build-arg PYTHON=3.6 --build-arg PLATFORM=ubuntu:18.04
+extract ${id}-py36
+
+build ${id}-py37 --build-arg PYTHON=3.7 --build-arg PLATFORM=ubuntu:18.04
+extract ${id}-py37
+
+# TODO(mwoehlke-kitware) VTK needs a patch to build against Python 3.8
+# build ${id}-py38 --build-arg PYTHON=3.8 --build-arg PLATFORM=ubuntu:18.04
+# extract ${id}-py38

--- a/image/build-wheel.sh
+++ b/image/build-wheel.sh
@@ -25,7 +25,7 @@ cp -r -t /wheel/pydrake \
 cp -r -t /wheel/pydrake/lib \
     /opt/drake/lib/libdrake*.so
 
-export LD_LIBRARY_PATH=/wheel/pydrake/lib
+export LD_LIBRARY_PATH=/wheel/pydrake/lib:/opt/drake-dependencies/lib
 
 chrpath '$ORIGIN/lib' pydrake/*.so
 chrpath '$ORIGIN/../lib' pydrake/*/*.so

--- a/image/dependencies/projects.cmake
+++ b/image/dependencies/projects.cmake
@@ -4,6 +4,12 @@ set(patchelf_url "https://github.com/NixOS/patchelf/archive/${patchelf_version}/
 set(patchelf_md5 "b9d1161e52e2f342598deabf7d85ed24")
 list(APPEND ALL_PROJECTS patchelf)
 
+# libxcrypt
+set(libxcrypt_version 4.4.25)
+set(libxcrypt_url "https://github.com/besser82/libxcrypt/archive/v${libxcrypt_version}/libxcrypt-${libxcrypt_version}.tar.gz")
+set(libxcrypt_md5 "4828b1530f5bf35af0b45b35acc4db1d")
+list(APPEND ALL_PROJECTS libxcrypt)
+
 # zlib
 set(zlib_version 1.2.11)
 set(zlib_url "https://github.com/madler/zlib/archive/v${zlib_version}.zip")

--- a/image/dependencies/projects/libxcrypt.cmake
+++ b/image/dependencies/projects/libxcrypt.cmake
@@ -1,0 +1,17 @@
+ExternalProject_Add(libxcrypt
+    URL ${libxcrypt_url}
+    URL_MD5 ${libxcrypt_md5}
+    ${COMMON_EP_ARGS}
+    BUILD_IN_SOURCE 1
+    PATCH_COMMAND ./autogen.sh
+    CONFIGURE_COMMAND ./configure
+        --prefix=${CMAKE_INSTALL_PREFIX}
+        --enable-shared
+        --enable-static
+        --enable-obsolete-api
+        --enable-hashes=all
+        CFLAGS=-fPIC
+        CXXFLAGS=-fPIC
+    BUILD_COMMAND make
+    INSTALL_COMMAND make install
+    )

--- a/image/pip-drake.patch
+++ b/image/pip-drake.patch
@@ -195,3 +195,23 @@ index d98b81c59..fb9bcd86c 100644
 
    ExecuteExtraPythonCode(m);
  }
+diff --git a/tools/py_toolchain/interpreter_paths.bzl b/tools/py_toolchain/interpreter_paths.bzl
+index 1608e49b1..d6b5d5e07 100644
+--- a/tools/py_toolchain/interpreter_paths.bzl
++++ b/tools/py_toolchain/interpreter_paths.bzl
+@@ -2,13 +2,13 @@
+
+ # Default value of interpreter_path used by the py_runtime in the default
+ # Python toolchain registered on the @platforms//os:linux platform.
+-LINUX_INTERPRETER_PATH = "/usr/bin/python3"
++LINUX_INTERPRETER_PATH = "/usr/local/bin/python"
+
+ # Default value of interpreter_path used by the py_runtime in the Python debug
+ # toolchain registered on the @platforms//os:linux platform when the
+ # --extra_toolchains=//tools/py_toolchain:linux_dbg_toolchain command line
+ # option is given.
+-LINUX_DBG_INTERPRETER_PATH = "/usr/bin/python3-dbg"
++LINUX_DBG_INTERPRETER_PATH = "/usr/local/bin/python"
+
+ # Default value of interpreter_path used by the py_runtime in the default
+ # Python toolchain registered on the @platforms//os:osx platform.

--- a/image/provision-base.sh
+++ b/image/provision-base.sh
@@ -3,14 +3,11 @@
 BAZEL_VERSION=4.2.1
 BAZEL_ROOT=https://github.com/bazelbuild/bazel/releases/download
 
-ln -s /usr/bin/python3 /usr/bin/python
-
 # Install prerequisites
 apt-get -y update
 
 apt-get -y install --no-install-recommends \
     autoconf automake default-jdk \
-    python3-dev libpython3-dev python3-pip \
     gcc g++ gfortran libgfortran-7-dev \
     libclang-9-dev clang-format-9 \
     git cmake ninja-build pkg-config \
@@ -20,13 +17,6 @@ apt-get -y install --no-install-recommends \
     libglib2.0-dev \
     libgl1-mesa-dev libxt-dev \
     opencl-headers ocl-icd-opencl-dev
-
-pip3 install \
-    pyyaml \
-    semantic-version \
-    setuptools \
-    wheel \
-    auditwheel
 
 # Install bazel
 cd /tmp

--- a/image/provision-base.sh
+++ b/image/provision-base.sh
@@ -7,7 +7,9 @@ BAZEL_ROOT=https://github.com/bazelbuild/bazel/releases/download
 apt-get -y update
 
 apt-get -y install --no-install-recommends \
-    autoconf automake default-jdk \
+    default-jdk \
+    autoconf automake \
+    libtool libltdl-dev \
     gcc g++ gfortran libgfortran-7-dev \
     libclang-9-dev clang-format-9 \
     git cmake ninja-build pkg-config \

--- a/image/provision-python.sh
+++ b/image/provision-python.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+PYTHON=python${1:-3}
+
+# Set up Python environment and install Python prerequisites
+apt-get -y install --no-install-recommends \
+    ${PYTHON}-dev lib${PYTHON}-dev ${PYTHON}-venv
+
+${PYTHON} -m venv /usr/local
+
+pip install \
+    pyyaml \
+    semantic-version \
+    setuptools \
+    wheel \
+    auditwheel
+
+ln -s /usr/bin/${PYTHON}-config /usr/bin/python3-config
+ln -s /usr/bin/${PYTHON}-config /usr/local/bin/python-config
+ln -s /usr/local/bin/python /usr/bin/python
+ln -s /usr/include/${PYTHON}m /usr/local/include/


### PR DESCRIPTION
Modify provisioning to set up a virtual Python environment, and accept an argument for what Python version to use. Add libxcrypt, which is required for complicated reasons (see commit). Modify `build-wheels.sh` to build for both Python 3.6 and 3.7.

Python 3.8 is not yet supported as it requires applying a patch to VTK. (We have the patch; fixing this is just logistics of applying it. However, this will probably be done in a separate PR.)