### PR TITLE
Use packaged nlopt

### DIFF
--- a/image/dependencies/projects.cmake
+++ b/image/dependencies/projects.cmake
@@ -106,12 +106,6 @@ set(suitesparse_url "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-$
 set(SuiteSparse_md5 "a2926c27f8a5285e4a10265cc68bbc18")
 list(APPEND ALL_PROJECTS suitesparse)
 
-# nlopt
-set(nlopt_version 2.6.2)
-set(nlopt_url "https://github.com/stevengj/nlopt/archive/v${nlopt_version}/nlopt-${nlopt_version}.tar.gz")
-set(nlopt_md5 "0163425f2ad26288391ce8f6a1fc418f")
-list(APPEND ALL_PROJECTS nlopt)
-
 # clp (TODO)
 list(APPEND ALL_PROJECTS clp)
 

--- a/image/dependencies/projects/nlopt.cmake
+++ b/image/dependencies/projects/nlopt.cmake
@@ -1,8 +1,0 @@
-ExternalProject_Add(nlopt
-    URL ${nlopt_url}
-    URL_MD5 ${nlopt_md5}
-    ${COMMON_EP_ARGS}
-    ${COMMON_CMAKE_EP_ARGS}
-    CMAKE_ARGS
-        ${COMMON_CMAKE_ARGS}
-    )

--- a/image/provision-base.sh
+++ b/image/provision-base.sh
@@ -16,7 +16,7 @@ apt-get -y install --no-install-recommends \
     yasm file wget unzip zip
 
 apt-get -y install --no-install-recommends \
-    libglib2.0-dev \
+    libglib2.0-dev libnlopt-dev \
     libgl1-mesa-dev libxt-dev \
     opencl-headers ocl-icd-opencl-dev
 


### PR DESCRIPTION
Most of the dependencies we build are so that we can have usable statically linked versions. However, for licensing (LGPL) reasons, we can't do this with nlopt. Therefore, revert to using the distro-provided version.

Fixes RobotLocomotion/drake#15757.