### PR TITLE
Ship dependencies' license files

### DIFF
--- a/image/build-wheel.sh
+++ b/image/build-wheel.sh
@@ -25,6 +25,9 @@ cp -r -t /wheel/pydrake \
 cp -r -t /wheel/pydrake/lib \
     /opt/drake/lib/libdrake*.so
 
+cp -r -t /wheel/pydrake/doc \
+    /opt/drake-dependencies/licenses/*
+
 rm /wheel/pydrake/examples/kuka_iiwa_arm/kuka_plan_runner
 rm /wheel/pydrake/examples/kuka_iiwa_arm/kuka_simulation
 

--- a/image/dependencies/CMakeLists.txt
+++ b/image/dependencies/CMakeLists.txt
@@ -31,6 +31,22 @@ set (COMMON_CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
     )
 
+function(extract_license PROJECT)
+    set(command "")
+    foreach(file IN LISTS ARGN)
+        list(APPEND command
+            COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_BINARY_DIR}/src/${PROJECT}/${file}
+            ${CMAKE_INSTALL_PREFIX}/licenses/${PROJECT}/${file}
+        )
+    endforeach()
+    ExternalProject_Add_Step(
+        ${PROJECT} CopyLicense
+        ${command}
+        DEPENDEES install
+    )
+endfunction()
+
 set_property(DIRECTORY PROPERTY EP_STEP_TARGETS download)
 foreach(project ${ALL_PROJECTS})
     include(projects/${project}.cmake)

--- a/image/dependencies/projects/bzip2.cmake
+++ b/image/dependencies/projects/bzip2.cmake
@@ -7,3 +7,7 @@ ExternalProject_Add(bzip2
     BUILD_COMMAND make "CFLAGS=-fPIC -O2"
     INSTALL_COMMAND make PREFIX=${CMAKE_INSTALL_PREFIX} install
     )
+
+extract_license(bzip2
+    LICENSE
+)

--- a/image/dependencies/projects/double-conversion.cmake
+++ b/image/dependencies/projects/double-conversion.cmake
@@ -6,3 +6,9 @@ ExternalProject_Add(double-conversion
     CMAKE_ARGS
         ${COMMON_CMAKE_ARGS}
     )
+
+# Note: double-conversion ships both a COPYING and a LICENSE, but they are
+# identical, so there is no need for us to ship both.
+extract_license(double-conversion
+    COPYING
+)

--- a/image/dependencies/projects/eigen.cmake
+++ b/image/dependencies/projects/eigen.cmake
@@ -7,3 +7,11 @@ ExternalProject_Add(eigen
     CMAKE_ARGS
         ${COMMON_CMAKE_ARGS}
 )
+
+# Note: Drake uses -DEIGEN_MPL2_ONLY, so we don't need the [L]GPL licenses.
+extract_license(eigen
+    COPYING.BSD
+    COPYING.MINPACK
+    COPYING.MPL2
+    COPYING.README
+)

--- a/image/dependencies/projects/gflags.cmake
+++ b/image/dependencies/projects/gflags.cmake
@@ -7,3 +7,7 @@ ExternalProject_Add(gflags
     CMAKE_ARGS
         ${COMMON_CMAKE_ARGS}
     )
+
+extract_license(gflags
+    COPYING.txt
+)

--- a/image/dependencies/projects/lapack.cmake
+++ b/image/dependencies/projects/lapack.cmake
@@ -8,3 +8,7 @@ ExternalProject_Add(lapack
         ${COMMON_CMAKE_ARGS}
         -DCBLAS=ON
 )
+
+extract_license(lapack
+    LICENSE
+)

--- a/image/dependencies/projects/libjpeg-turbo.cmake
+++ b/image/dependencies/projects/libjpeg-turbo.cmake
@@ -18,3 +18,7 @@ ExternalProject_Add(libjpeg-turbo
     BUILD_COMMAND make
     INSTALL_COMMAND make install
     )
+
+extract_license(libjpeg-turbo
+    README
+)

--- a/image/dependencies/projects/libtiff.cmake
+++ b/image/dependencies/projects/libtiff.cmake
@@ -14,3 +14,7 @@ ExternalProject_Add(libtiff
         -DZLIB_LIBRARY_DEBUG=${CMAKE_INSTALL_PREFIX}/lib/libz.a
         -DZLIB_LIBRARY_RELEASE=${CMAKE_INSTALL_PREFIX}/lib/libz.a
         )
+
+extract_license(libtiff
+    COPYRIGHT
+)

--- a/image/dependencies/projects/libxcrypt.cmake
+++ b/image/dependencies/projects/libxcrypt.cmake
@@ -15,3 +15,8 @@ ExternalProject_Add(libxcrypt
     BUILD_COMMAND make
     INSTALL_COMMAND make install
     )
+
+extract_license(libxcrypt
+    LICENSING
+    COPYING.LIB
+)

--- a/image/dependencies/projects/lz4.cmake
+++ b/image/dependencies/projects/lz4.cmake
@@ -12,3 +12,7 @@ ExternalProject_Add(lz4
         PREFIX=${CMAKE_INSTALL_PREFIX}
         install
     )
+
+extract_license(lz4
+    lib/LICENSE
+)

--- a/image/dependencies/projects/msgpack.cmake
+++ b/image/dependencies/projects/msgpack.cmake
@@ -6,3 +6,9 @@ ExternalProject_Add(msgpack
     CMAKE_ARGS
         ${COMMON_CMAKE_ARGS}
 )
+
+extract_license(msgpack
+    LICENSE_1_0.txt
+    COPYING
+    NOTICE
+)

--- a/image/dependencies/projects/patchelf.cmake
+++ b/image/dependencies/projects/patchelf.cmake
@@ -12,3 +12,6 @@ ExternalProject_Add(patchelf
     BUILD_COMMAND make
     INSTALL_COMMAND make install
     )
+
+# Note: patchelf is only used at build time, so there is no need to extract the
+# license for redistribution.

--- a/image/dependencies/projects/png.cmake
+++ b/image/dependencies/projects/png.cmake
@@ -10,3 +10,7 @@ ExternalProject_Add(png
         -DZLIB_INCLUDE_DIR:PATH=${CMAKE_INSTALL_PREFIX}/include
         -DZLIB_LIBRARY:PATH=${CMAKE_INSTALL_PREFIX}/lib/libz.a
     )
+
+extract_license(png
+    LICENSE
+)

--- a/image/dependencies/projects/suitesparse.cmake
+++ b/image/dependencies/projects/suitesparse.cmake
@@ -13,3 +13,10 @@ ExternalProject_Add(suitesparse
     BUILD_COMMAND make
     INSTALL_COMMAND make install
     )
+
+# Note: SuiteSparse consists of several "packages" with varying licenses; here,
+# we extract the licenses only for packages Drake actually uses. If the set of
+# used packages changes, this will need to be updated.
+extract_license(suitesparse
+    AMD/Doc/License.txt
+)

--- a/image/dependencies/projects/tinyxml2.cmake
+++ b/image/dependencies/projects/tinyxml2.cmake
@@ -7,3 +7,6 @@ ExternalProject_Add(tinyxml2
   CMAKE_ARGS
     ${COMMON_CMAKE_ARGS}
 )
+
+# Note: tinyxml2 uses the zlib license, which does not require the license
+# notice to be included in non-source distributions.

--- a/image/dependencies/projects/xz.cmake
+++ b/image/dependencies/projects/xz.cmake
@@ -11,3 +11,6 @@ ExternalProject_Add(xz
     BUILD_COMMAND make
     INSTALL_COMMAND make install
     )
+
+# Note: Although various utilities are under [L]GPL, we only use liblzma, which
+# is Public Domain.

--- a/image/dependencies/projects/yaml-cpp.cmake
+++ b/image/dependencies/projects/yaml-cpp.cmake
@@ -11,3 +11,7 @@ ExternalProject_Add(yaml-cpp
         -DYAML_CPP_BUILD_TESTS:BOOL=OFF
         -DYAML_CPP_BUILD_TOOLS:BOOL=OFF
 )
+
+extract_license(yaml-cpp
+    LICENSE
+)

--- a/image/dependencies/projects/zlib.cmake
+++ b/image/dependencies/projects/zlib.cmake
@@ -11,3 +11,6 @@ ExternalProject_Add(zlib
         -Dzlib_source=${CMAKE_BINARY_DIR}/src/zlib
         -P ${CMAKE_SOURCE_DIR}/patches/zlib/patch.cmake
 )
+
+# Note: the zlib license does not require the license notice to be included in
+# non-source distributions.


### PR DESCRIPTION
Add logic to gather license files of the various dependencies, as needed, into a common directory. Update wheel build to include these in the wheel.

Supersedes #18.