### PR TITLE
Don't build static libxcrypt

### DIFF
--- a/image/dependencies/projects/libxcrypt.cmake
+++ b/image/dependencies/projects/libxcrypt.cmake
@@ -6,8 +6,8 @@ ExternalProject_Add(libxcrypt
     PATCH_COMMAND ./autogen.sh
     CONFIGURE_COMMAND ./configure
         --prefix=${CMAKE_INSTALL_PREFIX}
+        --disable-static
         --enable-shared
-        --enable-static
         --enable-obsolete-api
         --enable-hashes=all
         CFLAGS=-fPIC


### PR DESCRIPTION
Because it is LGPL, we want to take extra care to only use shared libxcrypt, so disable building the static library. (I'm not even sure why this was ever enabled in the first place; it might have been by accident.)