### PR TITLE
Remove additional data files

### DIFF
--- a/image/build-wheel.sh
+++ b/image/build-wheel.sh
@@ -15,6 +15,7 @@ chrpath()
 mkdir -p /wheel/pydrake/lib
 cd /wheel
 
+# TODO we need a different way of shipping non-arch files (examples, models)
 cp -r -t /wheel/pydrake \
     /opt/drake/share/doc \
     /opt/drake/share/drake/.drake-find_resource-sentinel \
@@ -28,8 +29,12 @@ cp -r -t /wheel/pydrake/lib \
 cp -r -t /wheel/pydrake/doc \
     /opt/drake-dependencies/licenses/*
 
+# TODO we need to remove these to keep the wheel from being too large, but (per
+# above), the whole trees containing these bits shouldn't be in the wheel
 rm /wheel/pydrake/examples/kuka_iiwa_arm/kuka_plan_runner
 rm /wheel/pydrake/examples/kuka_iiwa_arm/kuka_simulation
+rm /wheel/pydrake/manipulation/models/ycb/meshes/*.png
+rm -r /wheel/pydrake/examples/atlas
 
 export LD_LIBRARY_PATH=/wheel/pydrake/lib:/opt/drake-dependencies/lib
 


### PR DESCRIPTION
Remove additional files when building the wheel in order to ensure it is below the PyPI package size limit. This is a temporary measure, as we really shouldn't be shipping ANY data files. However, it is not known when a proper redistribution method will be implemented.