### PR TITLE
Ensure CA certificates are up to date

### DIFF
--- a/image/provision-base.sh
+++ b/image/provision-base.sh
@@ -6,6 +6,8 @@ BAZEL_ROOT=https://github.com/bazelbuild/bazel/releases/download
 # Install prerequisites
 apt-get -y update
 
+apt-get -y install --reinstall ca-certificates
+
 apt-get -y install --no-install-recommends \
     default-jdk \
     autoconf automake \


### PR DESCRIPTION
During provisioning, force the system CA certificate package to be updated. This is needed to account for some recent root certificate expirations which affect some of Kitware's certificates. (In particular, the out-of-date certificates potentially present in the base image would prevent fetching VTK.)